### PR TITLE
Make fraction of second (SSS) optional in `toTime` parser

### DIFF
--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -287,8 +287,12 @@ iso8601 =
         |. symbol ":"
         |= paddedInt 2
         -- ss
-        |. symbol "."
-        |= paddedInt 3
+        |= oneOf
+            [ succeed identity
+                |. symbol "."
+                |= paddedInt 3
+            , succeed 0
+            ]
         -- SSS
         |= oneOf
             [ -- "Z" means UTC

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -18,6 +18,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "1970-01-01T00:00:00.000Z"
                     |> Expect.equal (Ok (Time.millisToPosix 0))
+        , test "toTime \"1970-01-01T00:00:00Z\" gives me 0" <|
+            \_ ->
+                Iso8601.toTime "1970-01-01T00:00:00Z"
+                    |> Expect.equal (Ok (Time.millisToPosix 0))
         ]
 
 


### PR DESCRIPTION
In our codebase we have ISO date strings without the fraction of second (SSS). Various documents seem to indicate that the fraction of second can be optional so both of these should be valid:
```elm
Iso8601.toTime "2018-01-01T12:00:00.000Z"
Iso8601.toTime "2018-01-01T12:00:00Z"
```

This PR updates the `toTime` parser to succeed with and without a fraction of second.

> If necessary for a particular application, the standard supports the addition of a decimal fraction to the smallest time value in the representation.
-- https://en.wikipedia.org/wiki/ISO_8601#General_principles

> The brackets indicate that the fraction of seconds component is optional.
-- https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2005/ms190977(v=sql.90)